### PR TITLE
Solution to problem where event instance could straddle two ModelEvalWindows.

### DIFF
--- a/magichour/api/local/modeleval/apply.py
+++ b/magichour/api/local/modeleval/apply.py
@@ -7,12 +7,14 @@ from magichour.api.local.util.namedtuples import TimedTemplate, TimedEvent
 
 logger = get_logger(__name__)
 
+
 def process_line(templates, logline):
     for template in templates:
         if template.match.match(logline.text):
-            return TimedTemplate(logline.ts, template.id)
+            return TimedTemplate(logline.ts, template.id, logline.id)
     # -1 = did not match any template
-    return TimedTemplate(logline.ts, -1)
+    return TimedTemplate(logline.ts, -1, logline.id)
+
 
 def process_auditd_line(templates, logline):
     first_key_val_pair = logline.text.split(' ', 1)[0]
@@ -23,7 +25,8 @@ def process_auditd_line(templates, logline):
     if audit_msg_type not in templates:
         raise KeyError("type=%s not in dictionary"%audit_msg_type)
 
-    return TimedTemplate(logline.ts, templates[audit_msg_type])
+    return TimedTemplate(logline.ts, templates[audit_msg_type], logline.id)
+
 
 def apply_templates(templates, loglines, mp=True, process_auditd=False):
     """
@@ -65,6 +68,7 @@ def apply_templates(templates, loglines, mp=True, process_auditd=False):
             timed_templates.append(process_function(templates, logline))
     return timed_templates
 
+
 #####
 
 
@@ -79,7 +83,7 @@ def counter_issubset(counter1, counter2):
     return not counter1 - counter2
 
 
-def apply_events(events, windows, mp=False):
+def apply_events_old(events, windows, mp=False):
     event_counters = {event.id : Counter(event.template_ids) for event in events}
     timed_events = []
     for window in windows:
@@ -100,4 +104,164 @@ def apply_events(events, windows, mp=False):
             for occurrence in xrange(0, num_occurrences):
                 timed_event = TimedEvent(window.start_time, window.end_time, event.id)
                 timed_events.append(timed_event)
+    return timed_events
+
+
+#####
+
+from collections import defaultdict
+
+
+def count_templates(timed_templates):
+    counts = defaultdict(int)
+    for timed_template in timed_templates:
+        counts[timed_template.template_id] += 1
+    return counts
+
+
+def get_least_common_template(template_counts, template_ids):
+    least_common_template = None
+    for template_id in template_ids:
+        if not least_common_template or template_counts[template_id] < template_counts[least_common_template]:
+            least_common_template = template_id
+    return least_common_template
+
+
+def jaccard(s1, s2):
+    return len(s1 & s2) / float(len(s1 | s2))
+
+
+def get_inner_list_vals(d):
+    d_vals = []
+    for d_val_list in d.itervalues():
+        for d_val in d_val_list:
+            d_vals.append(d_val)
+    return d_vals
+
+
+def jaccard_dicts(d1, d2, key_weight=0.0):
+    jaccard_keys = jaccard(d1.viewkeys(), d2.viewkeys())
+    d1_vals = get_inner_list_vals(d1)
+    d2_vals = get_inner_list_vals(d2)
+    jaccard_vals = jaccard(frozenset(d1_vals), frozenset(d2_vals))
+    return (jaccard_keys * key_weight) + (jaccard_vals * (1-key_weight))
+
+
+def calc_overlap(candidate_timed_template, orig_timed_template, logline_dict):
+    candidate = logline_dict[candidate_timed_template.logline_id].replacements
+    orig = logline_dict[orig_timed_template.logline_id].replacements
+    """
+    for k, v_list in orig.replacements.iteritems():
+        orig_v_set = set(v_list)
+        if k in candidate.replacements:
+            cand_v_set = set(candidate.replacements[k])
+            for cand_v in cand_v_set:
+                if cand_v in orig_v_set:
+                    overlap += len(cand_v) * weight_per_char
+    return (jaccard_keys * key_weight) + (jaccard_vals * (1-key_weight))
+    """
+    return jaccard_dicts(candidate, orig)
+
+
+"""
+def search_window(idx, event, timed_templates, logline_dict, window_size):
+    timed_template = timed_templates[idx]
+    results = [timed_template]
+    left_idx = idx-1
+    right_idx = idx+1
+
+    m = timed_template.ts % window_size
+    start_time = timed_template.ts - m
+    end_time = start_time + window_size
+
+    search_set = set(event.template_ids)
+    search_set.remove(timed_template.template_id)
+
+    while search_set and (left_idx >= 0 or right_idx <= len(timed_templates)):
+        candidates = defaultdict(list)
+        if left_idx >= 0:
+            l_timed_template = timed_templates[left_idx]
+            if l_timed_template.ts >= start_time and l_timed_template.template_id in search_set:
+                candidates[l_timed_template.template_id].append(l_timed_template)
+                #results.append(l_timed_template)
+                #search_set.remove(l_timed_template.template_id)
+        if right_idx < len(timed_templates):
+            r_timed_template = timed_templates[right_idx]
+            if r_timed_template.ts <= end_time and r_timed_template.template_id in search_set:
+                candidates[r_timed_template.template_id].append(r_timed_template)
+                #results.append(r_timed_template)
+                #search_set.remove(r_timed_template.template_id)
+
+        for template_id, candidate_list in candidates.iteritems():
+            if len(candidate_list) != 1:
+                candidate_list = sorted(candidate_list, reverse=True, key=lambda candidate: calc_overlap(candidate, timed_template, logline_dict))
+            winner = candidate_list[0]
+            logger.info(": %s", calc_overlap(winner, timed_template, logline_dict))
+            results.append(winner)
+            search_set.remove(winner.template_id)
+
+        left_idx -= 1
+        right_idx += 1
+
+    if search_set:
+        return None
+
+    return results
+"""
+
+def find_left_idx(idx, timed_templates, start_time):
+    left_idx = 0
+    for tt in reversed(timed_templates[:idx+1]):
+        if tt.ts < start_time:
+            break
+        left_idx += 1
+    return left_idx
+
+def find_right_idx(idx, timed_templates, end_time):
+    right_idx = 0
+    for tt in timed_templates[idx:]:
+        if tt.ts > end_time:
+            break
+        right_idx += 1
+    return right_idx
+
+def create_window(idx, timed_templates, window_size):
+    timed_template = timed_templates[idx]
+    start_time = timed_template.ts - (timed_template.ts % window_size)
+    end_time = start_time + window_size
+    left_idx = idx - find_left_idx(idx, timed_templates, start_time)
+    right_idx = idx + find_right_idx(idx, timed_templates, end_time)
+    return (left_idx, right_idx)
+
+def search_window(idx, event, timed_templates, logline_dict, window_size):
+    timed_template = timed_templates[idx]
+    left_idx, right_idx = create_window(idx, timed_templates, window_size)
+    window = timed_templates[left_idx:right_idx]
+    results = {timed_template.template_id : timed_template}
+    for template_id in event.template_ids:
+        if template_id != timed_template.template_id:
+            relevant = [tt for tt in window if tt.template_id == template_id]
+            if not relevant:
+                # We are missing one of the required template ID in this window
+                return []
+            relevant = sorted(relevant, reverse=True, key=lambda tt: calc_overlap(tt, timed_template, logline_dict))
+            results[template_id] = relevant[0]
+    return results.values()
+
+
+# assume timed_templates are ordered
+def apply_events(events, timed_templates, loglines, window_size=60, mp=False):
+    template_counts = count_templates(timed_templates)
+    logline_dict = {logline.id : logline for logline in loglines}
+    timed_events = []
+    for event in events:
+        lct_id = get_least_common_template(template_counts, event.template_ids)
+        for idx in xrange(0, len(timed_templates)):
+            timed_template = timed_templates[idx]
+            if timed_template.template_id == lct_id:
+                results = search_window(idx, event, timed_templates, logline_dict, window_size)
+                if results:
+                    s = sorted(results, key=lambda result: result.ts)
+                    timed_event = TimedEvent(event.id, timed_templates=s)
+                    timed_events.append(timed_event)
     return timed_events

--- a/magichour/api/local/modelgen/preprocess.py
+++ b/magichour/api/local/modelgen/preprocess.py
@@ -8,6 +8,7 @@ TODO: Add the ability to write custom preprocessing functions other than just tr
 
 import gzip
 import re
+import uuid
 
 from magichour.api.local.util.log import get_logger
 from magichour.api.local.util.namedtuples import LogLine, Transform
@@ -57,13 +58,13 @@ def read_log_file(file_path, ts_start_index, ts_end_index, ts_format=None, skip_
         else:
             ts = float(ts_str)
         text = line[:ts_start_index].join(line[ts_end_index:]).strip()
-        yield LogLine(ts, text, None, None , None)
+        yield LogLine(str(uuid.uuid4()), ts, text, None, None , None)
 
 
 def read_auditd_file(file_path):
     for line in _read_lines(file_path):
         ts = float(re.search('audit\(([0-9]+.[0-9]+)', line).group(1))
-        yield LogLine(ts, line.rstrip(), None, None, None)
+        yield LogLine(str(uuid.uuid4()), ts, line.rstrip(), None, None, None)
 
 
 #####
@@ -125,4 +126,4 @@ def transform_lines(lines, transforms_file):
             # Handle other transform types here.
             # if transform.type == 'EXAMPLE':
                 # do stuff
-        yield LogLine(logline.ts, transformed, None, replaceDict, None)
+        yield LogLine(str(uuid.uuid4()), logline.ts, transformed, None, replaceDict, None)

--- a/magichour/api/local/sample/auditd_driver.py
+++ b/magichour/api/local/sample/auditd_driver.py
@@ -78,12 +78,14 @@ def run_auditd_pipeline(options):
         logger.info("Discovered events:")
         logger.info("\n"+pformat(e))
 
+    """
     modeleval_windows = evalwindow_step(timed_templates, options.window_size)
     if options.save_intermediate:
         modeleval_windows_file = os.path.join(options.pickle_cache_dir, "modeleval_windows.pickle")
         write_pickle_file(modeleval_windows, modeleval_windows_file)
+    """
 
-    timed_events = evalapply_step(gen_events, modeleval_windows)
+    timed_events = evalapply_step(gen_events, timed_templates, loglines)
     if options.save_intermediate:
         timed_events_file = os.path.join(options.pickle_cache_dir, "timed_events.pickle")
         write_pickle_file(timed_events, timed_events_file)

--- a/magichour/api/local/sample/driver.py
+++ b/magichour/api/local/sample/driver.py
@@ -88,12 +88,13 @@ def main():
     logger.info("Discovered events:")
     logger.info("\n"+pformat(e))
     """
-
+    """
     modeleval_windows = evalwindow_step(timed_templates, window_size)
     write_pickle_file(modeleval_windows, modeleval_windows_file)
     #modeleval_windows = read_pickle_file(modeleval_windows_file)
+    """
 
-    timed_events = evalapply_step(gen_events, modeleval_windows)
+    timed_events = evalapply_step(gen_events, timed_templates, loglines)
     write_pickle_file(timed_events, timed_events_file)
     #timed_events = read_pickle_file(timed_events_file)
 

--- a/magichour/api/local/sample/steps/evalapply.py
+++ b/magichour/api/local/sample/steps/evalapply.py
@@ -4,7 +4,7 @@ from magichour.api.local.modeleval.apply import apply_events
 logger = get_logger(__name__)
 
 @log_time
-def evalapply_step(gen_events, modeleval_windows):
-    logger.info("Applying events to windows...")
-    timed_events = apply_events(gen_events, modeleval_windows)
+def evalapply_step(gen_events, timed_templates, loglines):
+    logger.info("Applying events to timed templates...")
+    timed_events = apply_events(gen_events, timed_templates, loglines)
     return timed_events

--- a/magichour/api/local/sample/steps/preprocess.py
+++ b/magichour/api/local/sample/steps/preprocess.py
@@ -17,9 +17,9 @@ def read_lines_substep(log_file, *args, **kwargs):
     return lines
 
 
-def transformed_lines_substep(lines, transforms):
+def transform_lines_substep(lines, transforms):
     logger.info("Transforming log lines...")
-    transformed_lines = preprocess.get_transformed_lines(lines, transforms)
+    transformed_lines = preprocess.transform_lines(lines, transforms)
     return transformed_lines
 
 
@@ -29,9 +29,8 @@ def _transformed_lines_to_list_substep(transformed_lines):
 
 @log_time
 def preprocess_step(log_file, transforms_file, *args, **kwargs):
-    transforms = read_transforms_substep(transforms_file)
     lines = read_lines_substep(log_file, *args, **kwargs)
-    transformed_lines = transformed_lines_substep(lines, transforms)
+    transformed_lines = transform_lines_substep(lines, transforms_file)
 
     # get_transformed_lines returns a generator. This converts it to a list.
     transformed_lines = _transformed_lines_to_list_substep(transformed_lines)

--- a/magichour/api/local/util/namedtuples.py
+++ b/magichour/api/local/util/namedtuples.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-LogLine = namedtuple("LogLine", ["ts", "text", "processed", "replacements", "supportId"])
+LogLine = namedtuple("LogLine", ["id", "ts", "text", "processed", "replacements", "supportId"])
 
 
 Transform = namedtuple('Transform', ['id', 'type', 'name', 'transform', 'compiled'])
@@ -9,7 +9,7 @@ Transform = namedtuple('Transform', ['id', 'type', 'name', 'transform', 'compile
 Template = namedtuple("Template", ["id", "match", "str"])
 
 
-TimedTemplate = namedtuple("TimedTemplate", ["ts", "template_id"])
+TimedTemplate = namedtuple("TimedTemplate", ["ts", "template_id", "logline_id"])
 
 
 ModelGenWindow = namedtuple("ModelGenWindow", ["template_ids"])
@@ -23,4 +23,4 @@ ModelEvalWindow = namedtuple("ModelEvalWindow", ["start_time", "end_time", "time
 Event = namedtuple("Event", ["id", "template_ids"])
 
 
-TimedEvent = namedtuple("TimedEvent", ["start_time", "end_time", "event_id"])
+TimedEvent = namedtuple("TimedEvent", ["event_id", "timed_templates"])

--- a/magichour/api/local/util/window.py
+++ b/magichour/api/local/util/window.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 def window(timed_templates, window_size=60, remove_junk_drawer=False, template_ids_only=False):
     windows = defaultdict(list)
     for timed_template in timed_templates:
-        t, template = timed_template
+        t, _, __ = timed_template
         key = math.floor(int(float(t)) / int(window_size))
         if not remove_junk_drawer or (remove_junk_drawer and timed_template.template_id != -1):
             if template_ids_only:

--- a/notebooks/sample_local.ipynb
+++ b/notebooks/sample_local.ipynb
@@ -518,75 +518,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Window (Model Evaluation)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create timed templates by applying templates generated from the last step (Template) over an iterable of LogLines."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "modeleval_windows = evalwindow_step(timed_templates, **modeleval_window_kwargs)\n",
-    "write_pickle_file(modeleval_windows, modeleval_windows_file)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Read windows from a prepared pickle file."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "modeleval_windows = read_pickle_file(modeleval_windows_file)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can examine and interact with the window output in the cell below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "modeleval_windows[9]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "# Apply Events"
    ]
   },
@@ -596,7 +527,9 @@
    "source": [
     "Create timed templates by applying templates generated from the last step (Template) over an iterable of LogLines.\n",
     "\n",
-    "**(\\*\\*WIP\\*\\*)** The way this currently works is by checking whether each event's template set is a subset within each window. If it is, then we create a TimedEvent for that window, otherwise we do nothing. This current method will miss any occurrences which straddle windows."
+    "The way this currently works is by determining which template for each event is the least frequently occurring template in timed_templates. By using the least frequently occuring template, we are guaranteed to not discover more than the maximum number of events allowed in a given list of timed_templates. \n",
+    "\n",
+    "For each event's least frequently occurring template, we construct a \"window\" around each instance in timed_templates, where a \"window\" is a collection of all of the timed_templates that occurred within the specified window size (60 secs by default). Within each window, for each of the remaining template types belonging to the event in question, we say that the logline with the highest Jaccard similarity score between its replacement values and the original frequently occuring template's replacement values. The logic here is that the closer the Jaccard similarity score, the more likely that the two loglines are talking about the same (machine, IP address, etc.)."
    ]
   },
   {
@@ -607,8 +540,9 @@
    },
    "outputs": [],
    "source": [
-    "timed_events = evalapply_step(gen_events, modeleval_windows)\n",
-    "write_pickle_file(timed_events, timed_events_file)"
+    "timed_events = evalapply_step(gen_events, timed_templates, loglines)\n",
+    "\n",
+    "#write_pickle_file(timed_events, timed_events_file)"
    ]
   },
   {
@@ -644,7 +578,36 @@
    },
    "outputs": [],
    "source": [
-    "timed_events[0]"
+    "timed_events"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "len(timed_events)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "[te.event_id for te in timed_events]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
    ]
   }
  ],


### PR DESCRIPTION
Added UUIDs to LogLine definitions. Also added reference to logline in timed_templates.

Removed modeleval windowing step. Switched implementation for apply_event to search for least common template and discover related loglines by using Jaccard similarity on replacement fields.